### PR TITLE
Add issue type config

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -2,9 +2,8 @@
 name: Bug report
 about: Create a report to help us improve
 title: "[BUG] "
-labels: bug
 assignees: ''
-
+type: Bug
 ---
 
 ## Describe the bug （不具合概要）

--- a/.github/ISSUE_TEMPLATE/documentation_request.md
+++ b/.github/ISSUE_TEMPLATE/documentation_request.md
@@ -4,7 +4,7 @@ about: Suggest a documentation idea for this project
 title: "[DOCS] "
 labels: documentation
 assignees: ''
-
+type: Task
 ---
 
 ## Outline（概要）

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,6 +4,7 @@ about: Suggest an idea for this project
 title: "[FEAT] "
 labels: enhancement
 assignees: 
+type: Feature
 ---
 
 ## Outline（概要）


### PR DESCRIPTION

## Major changes in codes/documents

This pull request updates the issue templates in the `.github/ISSUE_TEMPLATE` directory to standardize issue metadata by adding or modifying the `type` field in each template. This helps categorize issues more clearly and improves issue triage.

Issue template improvements:

* Added `type: Bug` to the `bug_report.md` template and removed the `labels: bug` field to clarify the issue type for bug reports.
* Added `type: Feature` to the `feature_request.md` template to explicitly mark feature requests.
* Added `type: Task` to the `documentation_request.md` template to better categorize documentation-related issues.